### PR TITLE
fix: support reference-style markdown links

### DIFF
--- a/src/checks/links.ts
+++ b/src/checks/links.ts
@@ -21,6 +21,7 @@ const PLACEHOLDER_SEGMENTS = new Set([
 
 /** Line-number anchors (`#L42`, `#L10-L20`) are a code-host feature, not a heading. */
 const LINE_ANCHOR = /^L\d+(?:-L?\d+)?$/;
+const FUTURE_ARTIFACT_LINE = /creat(e|ed|es|ing)|will be|generated|\(optional\)|if (it )?(does ?n[o']t|doesn't) exist/i;
 
 export function checkLinks(
   file: ContextFile,
@@ -32,9 +33,9 @@ export function checkLinks(
   const anchorCache = new Map<string, Set<string> | null>();
 
   for (const link of links) {
-    const srcLine = file.lines[link.line - 1] ?? "";
     // lines describing artifacts that get created later aren't claims about now
-    if (/creat(e|ed|es|ing)|will be|generated|\(optional\)|if (it )?(does ?n[o']t|doesn't) exist/i.test(srcLine)) continue;
+    const sourceLines = link.usageLines ?? [link.line];
+    if (sourceLines.every((line) => FUTURE_ARTIFACT_LINE.test(file.lines[line - 1] ?? ""))) continue;
 
     const rel = link.target ? path.posix.normalize(path.posix.join(fileDir === "." ? "" : fileDir, link.target)) : file.path;
     if (rel.startsWith("..")) continue; // escapes the scanned root — not ours to verify
@@ -53,7 +54,9 @@ export function checkLinks(
         line: link.line,
         message: `link target \`${link.target}\` does not exist.`,
         ...(elsewhere.length ? { hint: `did you mean \`${elsewhere.slice(0, 3).join("\`, \`")}\`?` } : {}),
-        ...(single ? { fix: { oldText: link.target, newText: relativeTo(fileDir, single) } } : {}),
+        ...(single && !link.isReference
+          ? { fix: { oldText: link.target, newText: relativeTo(fileDir, single) } }
+          : {}),
       });
       continue;
     }
@@ -74,7 +77,7 @@ export function checkLinks(
       line: link.line,
       message: `\`${link.target || rel}\` has no \`#${link.anchor}\` heading.`,
       ...(close.length ? { hint: `closest: \`#${close.join("\`, \`#")}\`` } : {}),
-      ...(close.length === 1 && close[0]
+      ...(close.length === 1 && close[0] && !link.isReference
         ? { fix: { oldText: `#${link.anchor}`, newText: `#${close[0]}` } }
         : {}),
     });

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -92,11 +92,21 @@ export interface LinkRef {
   target: string;
   anchor?: string;
   line: number;
+  /** Lines whose reference-style usages activated this definition. */
+  usageLines?: number[];
+  /** Reference definitions are reported but not auto-fixed ambiguously. */
+  isReference?: boolean;
 }
+
+const INLINE_LINK = /!?\[[^\]]*\]\(([^()\s]+(?:\s+"[^"]*")?)\)/g;
+const REFERENCE_DEFINITION = /^\s{0,3}\[([^\]\n]+)\]:\s*(<[^>\n]*>|\S+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*$/;
+const REFERENCE_USAGE = /(?<![\\!])!?\[([^\]\n]*)\]\[([^\]\n]*)\]/g;
 
 /** Markdown link/image targets that point inside the repo — `[x](docs/a.md#setup)`. */
 export function extractLinks(file: ContextFile): LinkRef[] {
   const links: LinkRef[] = [];
+  const definitions = collectReferenceDefinitions(file);
+  const referenceUsages = new Map<string, Set<number>>();
   let inFence = false;
   for (let i = 0; i < file.lines.length; i++) {
     const line = file.lines[i] ?? "";
@@ -108,25 +118,87 @@ export function extractLinks(file: ContextFile): LinkRef[] {
     if (inFence) continue;
     if (line.includes("driftlint-ignore") || prev.includes("driftlint-ignore")) continue;
 
-    for (const m of line.matchAll(/!?\[[^\]]*\]\(([^()\s]+(?:\s+"[^"]*")?)\)/g)) {
-      let t = (m[1] ?? "").replace(/\s+"[^"]*"$/, "").replace(/^<|>$/g, "");
-      try {
-        t = decodeURI(t);
-      } catch {
-        continue;
-      }
-      // external, site-absolute, and templated targets aren't repo claims
-      if (!t || /^[a-z][a-z0-9+.-]*:/i.test(t) || t.startsWith("//") || t.startsWith("/") || t.startsWith("~")) continue;
-      if (/[<>{}$*|`\\]/.test(t)) continue;
-      const hash = t.indexOf("#");
-      const target = hash === -1 ? t : t.slice(0, hash);
-      const anchor = hash === -1 ? undefined : t.slice(hash + 1).trim();
-      if (!target && !anchor) continue;
-      if (/(^|\/)path\/to(\/|$)/.test(target)) continue;
-      links.push({ target, ...(anchor ? { anchor } : {}), line: i + 1 });
+    if (REFERENCE_DEFINITION.test(line)) continue;
+
+    for (const m of line.matchAll(INLINE_LINK)) {
+      const link = parseLinkTarget(m[1] ?? "", i + 1);
+      if (link) links.push(link);
+    }
+
+    // Full and collapsed references only. Shortcut references (`[label]`) are
+    // intentionally excluded: without a markdown parser they collide with
+    // bracketed prose, footnotes, task markers, and code-span examples.
+    const referenceText = line.replace(INLINE_LINK, (link) => " ".repeat(link.length));
+    for (const m of referenceText.matchAll(REFERENCE_USAGE)) {
+      const label = normalizeReferenceLabel(m[2] || m[1] || "");
+      const definition = definitions.get(label);
+      if (!definition) continue;
+      const usageLines = referenceUsages.get(label) ?? new Set<number>();
+      usageLines.add(i + 1);
+      referenceUsages.set(label, usageLines);
     }
   }
+
+  for (const [label, usageLines] of referenceUsages) {
+    const definition = definitions.get(label);
+    if (definition) links.push({ ...definition, usageLines: [...usageLines], isReference: true });
+  }
+  links.sort((a, b) => a.line - b.line);
   return links;
+}
+
+/** Collect eligible definitions first so usages can precede them. */
+function collectReferenceDefinitions(file: ContextFile): Map<string, LinkRef | null> {
+  const definitions = new Map<string, LinkRef | null>();
+  let inFence = false;
+  for (let i = 0; i < file.lines.length; i++) {
+    const line = file.lines[i] ?? "";
+    const prev = i > 0 ? file.lines[i - 1] ?? "" : "";
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    if (line.includes("driftlint-ignore") || prev.includes("driftlint-ignore")) continue;
+
+    const m = REFERENCE_DEFINITION.exec(line);
+    if (!m?.[1] || !m[2]) continue;
+    const label = normalizeReferenceLabel(m[1]);
+    if (!label || definitions.has(label)) continue; // first definition wins
+    definitions.set(label, parseLinkTarget(m[2], i + 1));
+  }
+  return definitions;
+}
+
+function normalizeReferenceLabel(label: string): string {
+  return label.trim().replace(/\s+/g, " ").toUpperCase().toLowerCase();
+}
+
+function parseLinkTarget(
+  raw: string,
+  line: number,
+): LinkRef | null {
+  let targetWithAnchor = raw.replace(/\s+"[^"]*"$/, "").replace(/^<|>$/g, "");
+  try {
+    targetWithAnchor = decodeURI(targetWithAnchor);
+  } catch {
+    return null;
+  }
+  // External, site-absolute, and templated targets aren't repo claims.
+  if (
+    !targetWithAnchor ||
+    /^[a-z][a-z0-9+.-]*:/i.test(targetWithAnchor) ||
+    targetWithAnchor.startsWith("//") ||
+    targetWithAnchor.startsWith("/") ||
+    targetWithAnchor.startsWith("~")
+  ) return null;
+  if (/[<>{}$*|`\\]/.test(targetWithAnchor)) return null;
+  const hash = targetWithAnchor.indexOf("#");
+  const target = hash === -1 ? targetWithAnchor : targetWithAnchor.slice(0, hash);
+  const anchor = hash === -1 ? undefined : targetWithAnchor.slice(hash + 1).trim();
+  if (!target && !anchor) return null;
+  if (/(^|\/)path\/to(\/|$)/.test(target)) return null;
+  return { target, ...(anchor ? { anchor } : {}), line };
 }
 
 function cleanToken(raw: string): string | null {

--- a/test/v12.test.js
+++ b/test/v12.test.js
@@ -86,6 +86,78 @@ test("dead-link: links inside fences and driftlint-ignore lines are skipped", ()
   assert.deepEqual(links(dir), []);
 });
 
+test("dead-link: reference usages resolve once and report definition lines", () => {
+  const dir = tmp({
+    "CLAUDE.md": [
+      "# App",
+      "[readme]: README.md",
+      "",
+      "See [readme][], [deploy][ DePloY ], [architecture][arch], and ![removed][gone] plus [again][gone].",
+      "The generated report will be created at [report][report].",
+      "",
+      "[deploy]: docs/deploy.md#staging",
+      "[arch]: docs/architecture.md#components",
+      "[gone]: docs/gone.png",
+      "[gone]: README.md",
+      "[report]: docs/report.md",
+    ].join("\n"),
+    "README.md": "# Readme\n",
+    "docs/deploy.md": "# Deploy\n\n## Staging\n",
+    "docs/architecture.md": "# Architecture\n\n## Components\n",
+  });
+  const found = links(dir);
+  assert.equal(found.length, 1, "repeated usages share the first definition");
+  assert.equal(found[0].line, 9, "the editable definition owns the finding");
+  assert.match(found[0].message, /`docs\/gone\.png` does not exist/);
+});
+
+test("dead-link: unused, undefined, fenced, ignored, and non-repo references stay silent", () => {
+  const dir = tmp({
+    "CLAUDE.md": [
+      "# App",
+      "",
+      "[undefined][missing] [external][external] [absolute][absolute] [template][template] [placeholder][placeholder]",
+      "[ignored][ignored] <!-- driftlint-ignore -->",
+      "[hidden][hidden] has its definition only in a fence.",
+      "[inline](README.md \"[title][title]\") and \\[escaped][escaped] stay inline or escaped.",
+      "",
+      "```md",
+      "[fenced][fenced]",
+      "[hidden]: docs/hidden.md",
+      "```",
+      "",
+      "[external]: <https://example.com/docs>",
+      "[absolute]: /docs/absolute.md",
+      "[template]: docs/{name}.md",
+      "[placeholder]: path/to/file.md",
+      "[ignored]: docs/ignored.md",
+      "[fenced]: docs/fenced.md",
+      "[title]: docs/title.md",
+      "[escaped]: docs/escaped.md",
+      "[unused]: docs/unused.md",
+    ].join("\n"),
+    "README.md": "# Readme\n",
+  });
+  assert.deepEqual(links(dir), []);
+});
+
+test("dead-link: reference findings omit ambiguous auto-fixes", () => {
+  const dir = tmp({
+    "CLAUDE.md": [
+      "# App",
+      "",
+      "See [missing][docs/missing.md].",
+      "",
+      "[docs/missing.md]: docs/missing.md",
+    ].join("\n"),
+    "guides/missing.md": "# Found\n",
+  });
+  const found = links(dir);
+  assert.equal(found.length, 1);
+  assert.match(found[0].hint, /guides\/missing\.md/);
+  assert.equal(found[0].fix, undefined);
+});
+
 test("dead-link: memory audit validates MEMORY.md index pointers", () => {
   const repo = tmp({ "src/app.ts": "export {};\n" });
   const memory = tmp({


### PR DESCRIPTION
Closes #8.

## Summary

- collect reference definitions per context file and resolve full and collapsed link/image usages against them
- normalize labels, keep the first definition, ignore unused or undefined labels, and report one finding at the editable definition line
- preserve generated/future-artifact suppression across usage lines and omit ambiguous reference-definition auto-fixes

Shortcut references remain out of scope because they collide with ordinary bracketed prose, footnotes, and task markers without a full Markdown parser.

## Validation

- `npm run build`
- `node --test test/v12.test.js` — 10/10 passed
- `npm test` — 60 passed, 2 failed; both failures are unchanged on untouched `eb80e16` and are Windows path assumptions in `v05` and `v11`
- `npm install --no-save ..` and `npx tsc -p tsconfig.json` in `mcp/`
- `node dist/cli.js . --no-fail` completed and reported only the repository's fixture-intended findings
- `git diff --check HEAD^ HEAD`

An independent read-only review found no remaining correctness or safety blocker.

## Provenance

This pull request was implemented and validated autonomously by OpenAI Codex using the `LunaMeerkats` account. No human review or authorship is being claimed.