### PR TITLE
fix: .github/ was never walked, so copilot-instructions.md never loaded

### DIFF
--- a/src/fswalk.ts
+++ b/src/fswalk.ts
@@ -34,7 +34,7 @@ export function walk(root: string): WalkEntry[] {
       const abs = path.join(dir, d.name);
       const rel = path.relative(root, abs).split(path.sep).join("/");
       if (d.isDirectory()) {
-        if (IGNORED_DIRS.has(d.name) || d.name.startsWith(".git")) continue;
+        if (IGNORED_DIRS.has(d.name)) continue;
         entries.push({ rel, isDir: true });
         count++;
         visit(abs, depth + 1);

--- a/test/v13.test.js
+++ b/test/v13.test.js
@@ -5,6 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { execFileSync } from "node:child_process";
 import { scan } from "../dist/scan.js";
+import { walk } from "../dist/fswalk.js";
 import { badgeJson } from "../dist/badge.js";
 
 function tmp(files = {}) {
@@ -254,4 +255,29 @@ test("untracked-context: the personal-file hint only names CLAUDE.local.md for C
   );
   assert.match(byFile.get("CLAUDE.md")?.hint ?? "", /CLAUDE\.local\.md/);
   assert.doesNotMatch(byFile.get(".opencode/knowledge/notes.md")?.hint ?? "x", /CLAUDE\.local\.md/);
+});
+
+// --- discovery: .github ---
+
+test("discovery: .github/copilot-instructions.md is actually scanned", () => {
+  const dir = tmp({
+    ".github/copilot-instructions.md": "Entry point is `src/app.ts`; helper is `src/missing.ts`.\n",
+    ".github/workflows/ci.yml": "name: ci\n",
+    "src/app.ts": "export const a = 1;\n",
+  });
+  const res = scan(dir);
+  assert.deepEqual(res.contextFiles, [".github/copilot-instructions.md"]);
+  const dead = res.findings.filter((f) => f.rule === "dead-path");
+  assert.equal(dead.length, 1);
+  assert.match(dead[0].message, /src\/missing\.ts/);
+});
+
+test("walk: .git is still skipped, .github is not", () => {
+  const dir = tmp({
+    ".git/config": "[core]\n\trepositoryformatversion = 0\n",
+    ".github/copilot-instructions.md": "Guidance.\n",
+  });
+  const rels = walk(dir).map((e) => e.rel);
+  assert.ok(!rels.some((r) => r === ".git" || r.startsWith(".git/")), ".git stays out");
+  assert.ok(rels.includes(".github/copilot-instructions.md"), ".github is walked");
 });


### PR DESCRIPTION
Closes #11.

`walk()` skipped any directory whose name starts with `.git`, which also swallowed `.github`:

```ts
if (IGNORED_DIRS.has(d.name) || d.name.startsWith(".git")) continue;
```

`.git` is already in `IGNORED_DIRS`, so the prefix test only ever excluded `.github` (and `.gitlab`). That left the `copilot` context kind unreachable, even though it is wired up in `discover.ts`, typed in `types.ts`, and listed under **Scanned files** in the README.

Dropping the prefix test is the whole fix — `.git` stays excluded via `IGNORED_DIRS`.

### No new findings

This is the part I'd want reviewed hardest, given "precision beats coverage". Scanning this repo with the patched build gives an identical result set:

| | errors | warnings | total | context files |
|---|---:|---:|---:|---:|
| before | 11 | 4 | 16 | 20 |
| after | 11 | 4 | 16 | 20 |

Zero diff on finding keys (`rule|file|line`), not just on the counts.

That holds because every consumer of `walk()` is path-scoped: `configRefs` looks under `.claude`/`.cursor`/`.vscode-agent`/`.kiro`, `silentConfig` under `.cursor/rules` and `.claude/skills`, `deadCommands` at `package.json`/`Makefile` basenames. Nothing in `.github` matches those. `dead-path` also has an `fs.existsSync` fallback, so `.github/...` references already resolved before this change.

### Tests

Two tests in `test/v13.test.js`, both of which fail without the source change:

- `.github/copilot-instructions.md` is discovered and its dead path reported
- `.git` is still skipped while `.github` is not — the negative case, so this can't regress into walking `.git`

`npm test`: 79 → 81, all green.

### Scope

Deliberately left out: `discover.ts` matches `.github/copilot-instructions.md` with `rel === …`, so a nested one (`packages/web/.github/copilot-instructions.md`) still isn't picked up. That's a separate question from this bug and the README doesn't promise it — happy to open an issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
